### PR TITLE
Adjust instructions to go away from recommending creating a seperate `PAT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This project contains tools that make building and maintaining a [landscape](htt
 
 It is an evolution of the former [landscape-tools](https://github.com/jmertic/landscape-tools), with a refactor to add the ability to pull projects from LFX and generate text logos when a pure SVG does not exist. Additional differences include:
 
-- Only leverage LFX data for members and projects; no longer looks up in CrunchBase or other landscapes.
+- Only leverage LFX data for members and projects; no longer look up in CrunchBase or other landscapes.
 - Pull review data from a TAC repo using a specific project format, if used.
 - More verbose error messages that improve debugging.
 
 ## Configuration
 
-The default configuration for the build is located in the `config.yml` file, which you should put in the top directory in your landscape repo ( i.e. the same place you would have the `landscape.yml` file ). All options are defined at [lfx_landscape_tools/config.py](lfx_landscape_tools/config.py). See the below example for a simple `config.yml` file for building a members-only landscape.
+The default configuration for the build is located in the `config.yml` file, which you should put in the top directory in your landscape repo ( i.e. the same place you would have the `landscape.yml` file ). All options are defined at [lfx_landscape_tools/config.py](lfx_landscape_tools/config.py). See the example below for a simple `config.yml` file for building a members-only landscape.
 
 ```yaml
 # Membership levels; name is the membership level name in LFX; category is the matching subcategory name in the landscape
@@ -32,9 +32,8 @@ landscapeMemberCategory: AOUSD Members
 
 ## Setting up the GitHub Action
 
-1) Add [secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) for `PAT`, which is a [GitHub Personal Authorization Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) set for the `repo` scope.
-2) [Add a new label](https://docs.github.com/en/github/managing-your-work-on-github/managing-labels#creating-a-label) - `automated-build`. This is for this workflow to work and shouldn't be used for anything else.
-3) Add the following code to a `build.yml` file in your landscape repo's `.github/workflows/` directory.
+1) [Add a new label](https://docs.github.com/en/github/managing-your-work-on-github/managing-labels#creating-a-label) - `automated-build`. This is for this workflow to work and shouldn't be used for anything else.
+2) Add the following code to a `build.yml` file in your landscape repo's `.github/workflows/` directory.
 
 ```yaml
 name: Build Landscape from LFX
@@ -52,12 +51,11 @@ jobs:
         with:
           project_processing: skip # see options in action.yml
         env:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
 ```
-4) Add the following code to a `validate.yml` file in your landscape repo's `.github/workflows/` directory.
-
+3) Add the following code to a `validate.yml` file in your landscape repo's `.github/workflows/` directory.
 ```yaml
 name: Validate Landscape
 
@@ -81,12 +79,12 @@ jobs:
       - uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
         if: success() && ${{ github.secret_source == 'Actions' }}
         env:
-          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "automated-build"
           MERGE_RETRY_SLEEP: 300000
           MERGE_METHOD: "squash"
 ```
-5) Run the `Build Landscape from LFX` GitHub Action following the instructions for [manually running a GitHub Action](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) to test that it all works.
+4) Run the `Build Landscape from LFX` GitHub Action following the instructions for [manually running a GitHub Action](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) to test that it all works.
 
 ## Local install
 


### PR DESCRIPTION
Instead, leverage `secrets.GITHUB_TOKEN`

Fixes #160 