### PR TITLE
Specify base branch for release updates

### DIFF
--- a/.github/workflows/update-release-version.yml
+++ b/.github/workflows/update-release-version.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: release ${{ steps.meta.outputs.VERSION }}"
+          base: main # Explicitly target the protected branch
           branch: "release-updates-${{ steps.meta.outputs.VERSION }}"
           title: "Release Updates for ${{ steps.meta.outputs.VERSION }}"
           body: |


### PR DESCRIPTION
Explicitly target the protected branch 'main' for pull requests.