### PR TITLE
fix: isolate Member mutable defaults per instance to stop overlay leakage

### DIFF
--- a/lfx_landscape_tools/member.py
+++ b/lfx_landscape_tools/member.py
@@ -30,12 +30,8 @@ from lfx_landscape_tools.svglogo import SVGLogo
 class Member:
 
     membership = None
-    second_path = []
-    organization = {}
-    __extra = {}
     project = None
     project_org = None
-    additional_repos = []
     __name = None
     __homepage_url = None
     __logo = None
@@ -51,6 +47,15 @@ class Member:
     itemschema = []
 
     def __init__(self):
+        # Per-instance containers for mutable fields. Declaring these at
+        # class level would alias a single dict/list across every Member
+        # instance, causing values written to one member to surface on
+        # others (see sync_members leak symptoms).
+        self.second_path = []
+        self.organization = {}
+        self.__extra = {}
+        self.additional_repos = []
+
         # load in data schema from landscape2
         try:
             schemaURL = 'https://raw.githubusercontent.com/cncf/landscape2/refs/heads/main/docs/config/data.yml'

--- a/test/test_member.py
+++ b/test/test_member.py
@@ -714,6 +714,42 @@ class TestMember(unittest.TestCase):
         with unittest.mock.patch("lfx_landscape_tools.svglogo.open", unittest.mock.mock_open(read_data="data")) as mock_file:
             membertooverlay.overlay(member)
 
+    def testExtraIsolationBetweenInstances(self):
+        # Regression: writing extras via overlay on one Member must not
+        # leak to other Member instances through a shared class-level dict.
+        a = Member()
+        a.name = 'a'
+        a.homepage_url = 'https://a.example/'
+
+        b = Member()
+        b.name = 'b'
+        b.homepage_url = 'https://b.example/'
+
+        source = Member()
+        source.name = 'a'
+        source.extra = {'annotations': {'contact': 'a@example.com'}}
+        a.overlay(source)
+
+        self.assertEqual(a.extra.get('annotations', {}).get('contact'), 'a@example.com')
+        self.assertEqual(b.extra, {})
+
+        c = Member()
+        c.name = 'c'
+        c.homepage_url = 'https://c.example/'
+        source2 = Member()
+        source2.name = 'c'
+        source2.extra = {'annotations': {'demo_url2': 'https://example.com/demo'}}
+        c.overlay(source2)
+
+        self.assertNotIn('contact', c.extra.get('annotations', {}))
+        self.assertEqual(c.extra.get('annotations', {}).get('demo_url2'), 'https://example.com/demo')
+
+        d = Member()
+        self.assertEqual(d.extra, {})
+        self.assertEqual(d.second_path, [])
+        self.assertEqual(d.organization, {})
+        self.assertEqual(d.additional_repos, [])
+
     @responses.activate
     def testHostLogo(self):
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary

Move `Member`'s mutable containers (`second_path`, `organization`, `__extra`, `additional_repos`) from class-level defaults into `__init__`. Previously these were shared across every `Member` instance, so `overlay()`'s in-place dict mutation accumulated state into a single class-level dict, leaking extras from one member into every other member.

Fixes #340.

## Reproduction

```python
from lfx_landscape_tools.member import Member

a, b = Member(), Member()
a.name = 'a'; b.name = 'b'
a.homepage_url = 'https://a.example/'; b.homepage_url = 'https://b.example/'

src = Member()
src.name = 'a'
src.extra = {'annotations': {'contact': 'a@example.com'}}
a.overlay(src)

assert b.extra == {}  # fails on main: leaks a's annotations into b
```

Downstream example of the impact: [camaraproject/camara-landscape#282](https://github.com/camaraproject/camara-landscape/pull/282) adds Vodafone's `contact`/`demo_url` + Shabodi's `demo_url2` to 8 unrelated members.

## Fix

`lfx_landscape_tools/member.py`:

```diff
 class Member:

     membership = None
-    second_path = []
-    organization = {}
-    __extra = {}
     project = None
     project_org = None
-    additional_repos = []
     __name = None
     ...

     def __init__(self):
+        # Per-instance containers for mutable fields. Declaring these at
+        # class level would alias a single dict/list across every Member
+        # instance, causing values written to one member to surface on
+        # others (see sync_members leak symptoms).
+        self.second_path = []
+        self.organization = {}
+        self.__extra = {}
+        self.additional_repos = []
+
         # load in data schema from landscape2
```

## Regression test

Added `testExtraIsolationBetweenInstances` in `test/test_member.py`. It fails on main and passes with the fix:
- asserts a fresh `Member` whose sibling was overlaid keeps `extra == {}`
- asserts `overlay()` onto one member does not pollute a later, unrelated member
- asserts a brand-new `Member` has empty `second_path`, `organization`, `extra`, `additional_repos`

## Test results

```
Ran 77 tests (test_member, test_members, test_landscapemembers, test_lfxmembers)
75 passed
2 pre-existing errors unrelated to this change: testHostLogo, testLoadDataMissingLogo
  (both require a real cairo install for SVG rendering; fail identically on unmodified main)
```

No other test changes were needed.